### PR TITLE
Fix image-related issue

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,6 @@
  * @format
  */
 
-import 'react-native-gesture-handler';
 import { AppRegistry } from 'react-native';
 import App from './App';
 import { name as appName } from './app.json';


### PR DESCRIPTION
Remove unnecessary side-effect import of `react-native-gesture-handler` to fix "RNGestureHandlerModule could not be found" error on React Native 0.81/React 19 bridgeless runtime.

The `import 'react-native-gesture-handler';` statement in `index.js` is a legacy side-effect import that can cause a crash when using React Native 0.81 with the new bridgeless runtime, as it attempts to load the module incorrectly. The library's functionality is still available and correctly linked via autolinking and `GestureHandlerRootView` where it's actually used.

---
<a href="https://cursor.com/background-agent?bcId=bc-16b0d6a4-3e5b-4926-9f36-cf35103e84f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-16b0d6a4-3e5b-4926-9f36-cf35103e84f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

